### PR TITLE
Solving the bug of empty data 

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -16,6 +16,9 @@ void reader(std::vector< std::vector<int> >& data, std::string& filename, int& m
     }
     while (std::getline(infile, line)) {
         if (line.size() < 2) break;
+        if (line.empty() || std::all_of(line.begin(), line.end(), isspace)) {
+            break; // Exit the loop if an empty line is found
+        }
         std::istringstream iss(line);
         std::vector<int> tv;
         iss >> tmp;


### PR DESCRIPTION
在算法测试中，soloman_25算例集的C101.txt算例报错，经排查为该算例文件结尾存在空行，在读取数据时将空行也储存到了std::vector<std::vector>> data中，导致data中的实际长度大于节点数，读取到空数据报错。仍有其他算例结尾存在空行现象，所以做出更改——在正常的数据读取过程中，若读取到空行则读取结束。